### PR TITLE
 refactor: move to spark #19 

### DIFF
--- a/ci/pom.xml
+++ b/ci/pom.xml
@@ -14,8 +14,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
   <dependencies>
@@ -26,14 +26,14 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>4.0.1</version>
+      <groupId>com.sparkjava</groupId>
+      <artifactId>spark-core</artifactId>
+      <version>2.8.0</version>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-alpn-openjdk8-server</artifactId>
-      <version>9.4.26.v20200117</version>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.25</version>
     </dependency>
   </dependencies>
 

--- a/ci/src/main/java/group10/CIServer.java
+++ b/ci/src/main/java/group10/CIServer.java
@@ -1,47 +1,21 @@
 package group10;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.ServletException;
- 
-import java.io.IOException;
- 
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.Request;
-import org.eclipse.jetty.server.handler.AbstractHandler;
+import static spark.Spark.*;
 
-/** 
- Skeleton of a ContinuousIntegrationServer which acts as webhook
- See the Jetty documentation for API documentation of those classes.
-*/
-public class CIServer extends AbstractHandler
-{
-    public void handle(String target,
-                       Request baseRequest,
-                       HttpServletRequest request,
-                       HttpServletResponse response) 
-        throws IOException, ServletException
-    {
-        response.setContentType("text/html;charset=utf-8");
-        response.setStatus(HttpServletResponse.SC_OK);
-        baseRequest.setHandled(true);
-
-        System.out.println(target);
-
-        // here you do all the continuous integration tasks
-        // for example
-        // 1st clone your repository
-        // 2nd compile the code
-
-        response.getWriter().println("CI job done");
-    }
- 
+public class CIServer {
     // used to start the CI server in command line
     public static void main(String[] args) throws Exception
     {
-        Server server = new Server(8080);
-        server.setHandler(new CIServer()); 
-        server.start();
-        server.join();
+        port(8080);
+        // this is where HTML, CSS and images are stored
+        staticFiles.location("/public");
+        // this is the end point for displaying list of previous builds
+        get("/", (req, res) -> "todo make a list of builds!");
+        // this is the github post entrypoint
+        post("/api/github", (req, res) -> "todo");
+
+        exception(Exception.class, (exception, request, response) -> {
+            exception.printStackTrace();
+        });
     }
 }

--- a/ci/src/main/resources/public/index.html
+++ b/ci/src/main/resources/public/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+
+<h1>My First Heading</h1>
+
+<p>My first paragraph.</p>
+
+</body>
+</html>


### PR DESCRIPTION
**Description**
Use spark instead of Jetty, see issue #19. In CIServer.java you can see how much simpler Spark is compared to the Jetty implementation. This will speed up our progress and make the P+ criterion much easier to achieve. This also requires fewer dependencies (and fewer imports...).

It is now easy to access request parameters, craft responses and serve static files (such as HTML files).  

Spark documentation:
- http://sparkjava.com/documentation#response