### PR TITLE
feat: Input to clone function defines namespace of branch resolve #40

### DIFF
--- a/ci/src/main/java/group10/CIServer.java
+++ b/ci/src/main/java/group10/CIServer.java
@@ -70,7 +70,7 @@ public class CIServer {
     public boolean cloneRepository(String url, String branch, File cloneDirectoryPath) throws IOException {
         // Set which branch to clone
         ArrayList<String> branches = new ArrayList<>();
-        String branchPath = "refs/heads/" + branch;
+        String branchPath = branch;
         branches.add(branchPath);
 
         // Clone the repository

--- a/ci/src/test/java/group10/CloneTest.java
+++ b/ci/src/test/java/group10/CloneTest.java
@@ -38,7 +38,7 @@ public class CloneTest {
   public void cloneTest() throws IOException
     {
         String repoUrl = "https://github.com/jonasjungaker/DD2480_A2_CI_Group10";
-        boolean result = ci.cloneRepository(repoUrl, "master", cloneDirectoryPath);
+        boolean result = ci.cloneRepository(repoUrl, "refs/heads/master", cloneDirectoryPath);
         assertTrue(cloneDirectoryPath.exists() && result);
     }
 
@@ -51,7 +51,7 @@ public class CloneTest {
   public void branchNotExistTest() throws IOException
     {
         String repoUrl = "https://github.com/jonasjungaker/DD2480_A2_CI_Group10";
-        boolean result = ci.cloneRepository(repoUrl, "aNonExistingBranch", cloneDirectoryPath);
+        boolean result = ci.cloneRepository(repoUrl, "refs/heads/aNonExistingBranch", cloneDirectoryPath);
         assertFalse(cloneDirectoryPath.exists() || result);
         
     }


### PR DESCRIPTION
Instead of defining namespace of branch in cloneRepository the input branch defines the namespace itself. See #40