### PR TITLE
bug: Change filepath to work on Mac  resolve #57

### DIFF
--- a/ci/src/main/java/group10/GithubController.java
+++ b/ci/src/main/java/group10/GithubController.java
@@ -33,7 +33,7 @@ public class GithubController {
         
         // todo set commit pending
         // clone repo
-        File cloneDirectoryPath = new File("/clone");
+        File cloneDirectoryPath = new File("clone");
         boolean cloned = false;
         try {
             cloned = ciServer.cloneRepository(relevant_data.getString("clone_url"), relevant_data.getString("ref"),


### PR DESCRIPTION
Filepath with slash(/) before it was invalid on mac removed the slash from the clone function