### PR TITLE
bug: set max length on error msg to 200 to fit database resolve #68

### DIFF
--- a/ci/src/main/java/group10/ReadTestResults.java
+++ b/ci/src/main/java/group10/ReadTestResults.java
@@ -58,7 +58,10 @@ public class ReadTestResults {
                         //If test failed add details of fail
                         if(child != null){
                             number_failed++;
-                            test.put("cause", nodeTestCases.item(i).getTextContent());
+                            String causeString = nodeTestCases.item(i).getTextContent();
+                            int maxLength = (causeString.length() < 190?causeString.length():190);
+                            causeString = causeString.substring(0, maxLength);
+                            test.put("cause", causeString);
                             failed.put(test);                       
                         }else{
                             number_success++;

--- a/ci/src/test/java/group10/ReadTestResultTest.java
+++ b/ci/src/test/java/group10/ReadTestResultTest.java
@@ -27,7 +27,9 @@ public class ReadTestResultTest {
         assertEquals(1, json.getInt("number_failed"));
         assertEquals(2, json.getInt("number_success"));
         JSONObject n = (JSONObject) json.getJSONArray("failed").get(0);
-        assertTrue(n.getString("cause").contains("AssertionError"));
+        String cause = n.getString("cause");
+        assertTrue(cause.length() <= 200);
+        assertTrue(cause.contains("AssertionError"));
         assertTrue(n.getString("time").contains("0.005"));
         assertTrue(n.getString("classname").contains("AppTest"));
     }


### PR DESCRIPTION
The cause of error messages from tests was to long to fit in database, set a max length on what we save