### PR TITLE
bug: change directory that that the clone test clones to resolve #77

### DIFF
--- a/ci/src/test/java/group10/GithubControllerTest.java
+++ b/ci/src/test/java/group10/GithubControllerTest.java
@@ -18,7 +18,7 @@ public class GithubControllerTest {
 
     @After
     public void tearDown() throws IOException {
-        GithubController.tearDown(new File("clone"));
+        GithubController.tearDown(new File("testCloneDirectory"));
     }
 
     /**


### PR DESCRIPTION
The actual function cloneRepository(...) and the test for cloneRepository now use different folders to clone to since we can not clone to a folder that has content which caused an error