### PR TITLE
bug: Set url to reach a single build in commit status resolve #95

### DIFF
--- a/ci/src/main/java/group10/GithubController.java
+++ b/ci/src/main/java/group10/GithubController.java
@@ -141,7 +141,7 @@ public class GithubController {
         String token = FileConfig.getRow(1);
         String url = statuses_url.replace("{sha}", sha);
         String description = "";
-        String target_url = "http://johvh.se/build/"+ buildID;
+        String target_url = "http://server.johvh.se/build/"+ buildID;
 
         if(state.equals("buildFailed")){
             state = "failure";


### PR DESCRIPTION
The url to reach a single build from the commit status was changed to the correct one