### PR TITLE
fix: move config file outside repo #101

### DIFF
--- a/ci/config.txt
+++ b/ci/config.txt
@@ -1,2 +1,0 @@
-mdksamdlamd
-dmsakdmkalwd

--- a/ci/src/main/java/group10/FileConfig.java
+++ b/ci/src/main/java/group10/FileConfig.java
@@ -11,7 +11,7 @@ public class FileConfig {
      */
     public static String getRow(int row) {
         String line = "";
-        String path = System.getProperty("user.dir") + "/";
+        String path = System.getProperty("user.dir") + "/../../";
         int i = -1;
         try {
             BufferedReader br = new BufferedReader(new FileReader(path+"config.txt"));


### PR DESCRIPTION
Moves the config file one step outside the directory, see below. In order to pass the tests, the config file has to be there!!

```
- config.txt
- DD2480_A2_CI_Group10
----ci/
----README.md
```