### PR TITLE
bug: Clone folder is given a random name resolve #114

### DIFF
--- a/ci/src/main/java/group10/GithubController.java
+++ b/ci/src/main/java/group10/GithubController.java
@@ -27,6 +27,7 @@ import java.io.DataOutputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.util.Base64;
+import java.util.Random;
 import java.net.URL;
 
 public class GithubController {
@@ -51,7 +52,9 @@ public class GithubController {
 
         // clone repo
         System.out.println("Began cloning repository...");
-        File cloneDirectoryPath = new File("clone/");
+        Random r = new Random();
+        String cloneDir = "clone" + r.nextInt(1000)+ "/";
+        File cloneDirectoryPath = new File(cloneDir);
         boolean cloned = false;
         try {
             cloned = cloneRepository(relevant_data.getString("clone_url"), relevant_data.getString("ref"),


### PR DESCRIPTION
Added a random number in the name of the clone folder to enable multiple commits at once